### PR TITLE
git clone needs --recursive as external-modules/spark is a submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To [install Singularity](https://sylabs.io/guides/3.7/admin-guide/installation.h
 
 Clone this repository with the following command:
 
-    git clone https://github.com/JaneliaSciComp/multifish.git
+    git clone --recursive https://github.com/JaneliaSciComp/multifish.git
 
 Before running the pipeline for the first time, run setup to pull in external dependencies:
 

--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -27,7 +27,7 @@ To [install Singularity](https://sylabs.io/guides/3.7/admin-guide/installation.h
 
 Once the prerequisites are installed, you should clone this repository with the following command:
 
-    git clone https://github.com/JaneliaSciComp/multifish.git
+    git clone --recursive https://github.com/JaneliaSciComp/multifish.git
 
 Before running the pipeline for the first time, run setup to pull in external dependencies:
 


### PR DESCRIPTION
I think the because external-modules/spark is a submodule, the git clone command needs a `--recursive`. 
When I cloned without `--recursive` and tried to run the sample data example (./examples/demo_tiny.sh) I got this error:
 `No such file: Config file does not exist: /home/oamsalem/Downloads/multifish/external-modules/spark/nextflow.config` 
It was fixed when I cloned with `--recursive`